### PR TITLE
bugfix: DB availability wasn't checked in GetCraftingTime()

### DIFF
--- a/AdvancedTradeSkillWindow2/AdvancedTradeSkillWindow2.lua
+++ b/AdvancedTradeSkillWindow2/AdvancedTradeSkillWindow2.lua
@@ -1351,7 +1351,7 @@ local function GetCraftingTime(Name, Amount)
 	local ID = GetRecipeID(Name)
 	local Cost = ATSW_TimeCost[ID]
 	
-	if not Cost then
+	if DB and not Cost then
 		local DB = GetSpellInfoVanillaDB
 		local AtlasID = CraftIDtoAtlasID(ID)
 		


### PR DESCRIPTION
The addon is broken if GetSpellInfoVanillaDB is missing:

Opening the crafting window and switching tabs works well (craftable items appears and whatnot). But results in this error : `AdvancedTradeSkillWindow2.lua:694: attempt to index local 'DB' (a nil value)`.

Clicking on "Task" and "Create" buttons resulted as the same error as well, but without any action.

This patch fixes this problem.