### PR TITLE
Fix bug where profession appeared multiple times

### DIFF
--- a/AdvancedTradeSkillWindow2/AdvancedTradeSkillWindow2.lua
+++ b/AdvancedTradeSkillWindow2/AdvancedTradeSkillWindow2.lua
@@ -1970,10 +1970,12 @@ function ATSW_ConfigureSkillButtons(Exception)
 			local Tab = getglobal("ATSWFrameTab"..T)
 			
 			if Tab then
-				local Tex = Tab:GetNormalTexture()
-				
-				if Tex and Tex:GetTexture() == Texture then
-					return true
+				local NormalTexture = Tab:GetNormalTexture()
+				if NormalTexture then
+					local Tex = NormalTexture:GetTexture()
+					if Tex and string.lower(Tex) == string.lower(Texture) then
+						return true
+					end
 				end
 			end
 		end


### PR DESCRIPTION
I'm not very familiar with WoW addon programming, so I don't know what caused this, but what I observed was that my ATSW window was showing Alchemy, Cooking, and then First Aid 6 times.

I looked a bit into it and discovered that the check for whether a profession had already been added was done by comparing the texture of the tab icon.

For some reason, on my version of the client (TurtleWoW with some modifications), the strings being compared were the same, but one was lowercase, and the other one had some words capitalized.
I believe this fix should avoid such situations in the future, but if this is not good enough, please let me know what's wrong with the approach and I'll try to find a different one.